### PR TITLE
编辑图片过程中的一个小Bug

### DIFF
--- a/multilibrary/src/main/java/com/zhongjh/albumcamerarecorder/camera/adapter/PhotoAdapter.java
+++ b/multilibrary/src/main/java/com/zhongjh/albumcamerarecorder/camera/adapter/PhotoAdapter.java
@@ -103,6 +103,7 @@ public class PhotoAdapter extends RecyclerView.Adapter<PhotoAdapter.PhotoViewHol
         ArrayList<MultiMedia> items = new ArrayList<>();
         for (BitmapData item : mListData) {
             MultiMedia multiMedia = new MultiMedia();
+            multiMedia.setId(mListData.indexOf(item));
             multiMedia.setUri(item.getUri());
             multiMedia.setPath(item.getPath());
             multiMedia.setMimeType(MimeType.JPEG.toString());


### PR DESCRIPTION
PhotoAdapter(横向) 向 AlbumPreviewActivity 传递的 MultiMedia 数据没有设置 id, 导致编辑保存图片的处理逻辑异常;