### PR TITLE
Fixed NullPointerException when only using one of album/shooting/recording.

### DIFF
--- a/multilibrary/src/main/java/com/zhongjh/albumcamerarecorder/MainActivity.java
+++ b/multilibrary/src/main/java/com/zhongjh/albumcamerarecorder/MainActivity.java
@@ -135,7 +135,9 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        mLayoutMediator.detach();
+        if (mLayoutMediator != null) {
+            mLayoutMediator.detach();
+        }
     }
 
     @Override


### PR DESCRIPTION
It was introduced by commit 06103534ecfabc8158ffab9373c4200ce04de040

Crash log:

2022-08-19 21:57:00.813 9696-9696/com.zhongjh.cameraapp E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.zhongjh.cameraapp, PID: 9696
    java.lang.RuntimeException: Unable to destroy activity {com.zhongjh.cameraapp/com.zhongjh.albumcamerarecorder.MainActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'void com.google.android.material.tabs.TabLayoutMediator.detach()' on a null object reference
        at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:5387)
        at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:5420)
        at android.app.servertransaction.DestroyActivityItem.execute(DestroyActivityItem.java:47)
        at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:45)
        at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2210)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.app.ActivityThread.main(ActivityThread.java:7839)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
     Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'void com.google.android.material.tabs.TabLayoutMediator.detach()' on a null object reference
        at com.zhongjh.albumcamerarecorder.MainActivity.onDestroy(MainActivity.java:139)
        at android.app.Activity.performDestroy(Activity.java:8316)
        at android.app.Instrumentation.callActivityOnDestroy(Instrumentation.java:1364)
        at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:5374)
        at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:5420) 
        at android.app.servertransaction.DestroyActivityItem.execute(DestroyActivityItem.java:47) 
        at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:45) 
        at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176) 
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97) 
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2210) 
        at android.os.Handler.dispatchMessage(Handler.java:106) 
        at android.os.Looper.loopOnce(Looper.java:201) 
        at android.os.Looper.loop(Looper.java:288) 
        at android.app.ActivityThread.main(ActivityThread.java:7839) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003) 
2022-08-19 21:57:01.303 9696-9696/com.zhongjh.cameraapp E/CustomActivityOnCrash: App has crashed, executing CustomActivityOnCrash's UncaughtExceptionHandler
    java.lang.RuntimeException: Unable to destroy activity {com.zhongjh.cameraapp/com.zhongjh.albumcamerarecorder.MainActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'void com.google.android.material.tabs.TabLayoutMediator.detach()' on a null object reference
        at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:5387)
        at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:5420)
        at android.app.servertransaction.DestroyActivityItem.execute(DestroyActivityItem.java:47)
        at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:45)
        at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2210)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.app.ActivityThread.main(ActivityThread.java:7839)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
     Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'void com.google.android.material.tabs.TabLayoutMediator.detach()' on a null object reference
        at com.zhongjh.albumcamerarecorder.MainActivity.onDestroy(MainActivity.java:139)
        at android.app.Activity.performDestroy(Activity.java:8316)
        at android.app.Instrumentation.callActivityOnDestroy(Instrumentation.java:1364)
        at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:5374)
        at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:5420) 
        at android.app.servertransaction.DestroyActivityItem.execute(DestroyActivityItem.java:47) 
        at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:45) 
        at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176) 
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97) 
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2210) 
        at android.os.Handler.dispatchMessage(Handler.java:106) 
        at android.os.Looper.loopOnce(Looper.java:201) 
        at android.os.Looper.loop(Looper.java:288) 
        at android.app.ActivityThread.main(ActivityThread.java:7839) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003) 
2022-08-19 21:57:01.940 9785-9785/com.zhongjh.cameraapp E/CustomActivityOnCrash: The previous app process crashed. This is the stack trace of the crash:
    java.lang.RuntimeException: Unable to destroy activity {com.zhongjh.cameraapp/com.zhongjh.albumcamerarecorder.MainActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'void com.google.android.material.tabs.TabLayoutMediator.detach()' on a null object reference
        at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:5387)
        at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:5420)
        at android.app.servertransaction.DestroyActivityItem.execute(DestroyActivityItem.java:47)
        at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:45)
        at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2210)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.app.ActivityThread.main(ActivityThread.java:7839)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
     Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'void com.google.android.material.tabs.TabLayoutMediator.detach()' on a null object reference
        at com.zhongjh.albumcamerarecorder.MainActivity.onDestroy(MainActivity.java:139)
        at android.app.Activity.performDestroy(Activity.java:8316)
        at android.app.Instrumentation.callActivityOnDestroy(Instrumentation.java:1364)
        at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:5374)
        at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:5420) 
        at android.app.servertransaction.DestroyActivityItem.execute(DestroyActivityItem.java:47) 
        at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:45) 
        at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176) 
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97) 
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2210) 
        at android.os.Handler.dispatchMessage(Handler.java:106) 
        at android.os.Looper.loopOnce(Looper.java:201) 
        at android.os.Looper.loop(Looper.java:288) 
        at android.app.ActivityThread.main(ActivityThread.java:7839) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003) 
