### PR TITLE
修复不能双指缩放相机问题

### DIFF
--- a/multilibrary/src/main/java/com/zhongjh/albumcamerarecorder/MainActivity.java
+++ b/multilibrary/src/main/java/com/zhongjh/albumcamerarecorder/MainActivity.java
@@ -265,9 +265,9 @@ public class MainActivity extends AppCompatActivity {
                 mLayoutMediator = new TabLayoutMediator(mTabLayout, mVpPager, false, true,
                         (tab, position) -> tab.setText(adapterViewPager.mTitles.get(position)));
                 mLayoutMediator.attach();
-                // 禁滑viewPager
-                mVpPager.setUserInputEnabled(false);
             }
+            // 禁滑viewPager
+            mVpPager.setUserInputEnabled(false);
 
             mTabLayout.addOnTabSelectedListener(new TabLayout.OnTabSelectedListener() {
                 @Override


### PR DESCRIPTION
即使ViewPager2只有一个页面，也要禁止滑动，不然手势动不动就会被它捕获，双指缩放相机功能就不行了